### PR TITLE
Fix windows blocking

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -49,13 +49,13 @@ chrome <- function(port = 4567L, version = "latest", path = "wd/hub",
   write(character(), errTfile)
   outTfile <- tempfile(fileext = ".txt")
   write(character(), outTfile)
-  seleniumdrv <- if(identical(.Platform[["OS.type"]], "windows")){
+  chromedrv <- if(identical(.Platform[["OS.type"]], "windows")){
     tfile <- tempfile(fileext = ".bat")
     write(paste(c(chromeversion[["path"]], args), collapse = " "), tfile)
     subprocess::spawn_process(tfile, arguments = c(">", outTfile,
                                                    "2>", errTfile))
   }else{
-    chromedrv <- subprocess::spawn_process(
+    subprocess::spawn_process(
       chromeversion[["path"]], arguments = args
     )
   }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -45,14 +45,27 @@ chrome <- function(port = 4567L, version = "latest", path = "wd/hub",
   if(retcommand){
     return(paste(c(chromeversion[["path"]], args), collapse = " "))
   }
-  chromedrv <- subprocess::spawn_process(
-    chromeversion[["path"]], arguments = args
-  )
+  errTfile <- tempfile(fileext = ".txt")
+  write(character(), errTfile)
+  outTfile <- tempfile(fileext = ".txt")
+  write(character(), outTfile)
+  seleniumdrv <- if(identical(.Platform[["OS.type"]], "windows")){
+    tfile <- tempfile(fileext = ".bat")
+    write(paste(c(chromeversion[["path"]], args), collapse = " "), tfile)
+    subprocess::spawn_process(tfile, arguments = c(">", outTfile,
+                                                   "2>", errTfile))
+  }else{
+    chromedrv <- subprocess::spawn_process(
+      chromeversion[["path"]], arguments = args
+    )
+  }
   if(!is.na(subprocess::process_return_code(chromedrv))){
     stop("Chromedriver couldn't be started",
          subprocess::process_read(chromedrv, "stderr"))
   }
-  startlog <- generic_start_log(chromedrv)
+  startlog <- generic_start_log(chromedrv,
+                                outfile = outTfile,
+                                errfile = errTfile)
   if(length(startlog[["stderr"]]) >0){
     if(any(grepl("Address already in use", startlog[["stderr"]]))){
       subprocess::process_kill(chromedrv)
@@ -63,14 +76,16 @@ chrome <- function(port = 4567L, version = "latest", path = "wd/hub",
   list(
     process = chromedrv,
     output = function(timeout = 0L){
-      infun_read(chromedrv, log, "stdout", timeout = timeout)
+      infun_read(chromedrv, log, "stdout", timeout = timeout,
+                 outfile = outTfile, errfile = errTfile)
     },
     error = function(timeout = 0L){
-      infun_read(chromedrv, log, "stderr", timeout = timeout)
+      infun_read(chromedrv, log, "stderr", timeout = timeout,
+                 outfile = outTfile, errfile = errTfile)
     },
     stop = function(){subprocess::process_kill(chromedrv)},
     log = function(){
-      infun_read(chromedrv, log)
+      infun_read(chromedrv, log, outfile = outTfile, errfile = errTfile)
       as.list(log)
     }
   )

--- a/R/iedriver.R
+++ b/R/iedriver.R
@@ -68,7 +68,9 @@ iedriver <- function(port = 4567L, version = "latest", check = TRUE,
     stop("iedriver couldn't be started",
          subprocess::process_read(iedrv, "stderr"))
   }
-  startlog <- generic_start_log(iedrv)
+  startlog <- generic_start_log(iedrv,
+                                outfile = outTfile,
+                                errfile = errTfile)
   if(length(startlog[["stderr"]]) >0){
     if(any(grepl("Address in use", startlog[["stderr"]]))){
       subprocess::process_kill(iedrv)

--- a/R/phantom.R
+++ b/R/phantom.R
@@ -64,7 +64,9 @@ phantomjs <- function(port = 4567L, version = "2.1.1", check = TRUE,
     stop("PhantomJS couldn't be started",
          subprocess::process_read(phantomdrv, "stderr"))
   }
-  startlog <- generic_start_log(phantomdrv)
+  startlog <- generic_start_log(phantomdrv,
+                                outfile = outTfile,
+                                errfile = errTfile)
   if(length(startlog[["stdout"]]) >0){
     if(any(
       grepl("GhostDriver - main.fail.*sourceURL", startlog[["stdout"]])

--- a/R/phantom.R
+++ b/R/phantom.R
@@ -46,9 +46,20 @@ phantomjs <- function(port = 4567L, version = "2.1.1", check = TRUE,
   if(retcommand){
     return(paste(c(phantomversion[["path"]], args), collapse = " "))
   }
-  phantomdrv <- subprocess::spawn_process(
-    phantomversion[["path"]], arguments = args
-  )
+  errTfile <- tempfile(fileext = ".txt")
+  write(character(), errTfile)
+  outTfile <- tempfile(fileext = ".txt")
+  write(character(), outTfile)
+  phantomdrv <- if(identical(.Platform[["OS.type"]], "windows")){
+    tfile <- tempfile(fileext = ".bat")
+    write(paste(c(phantomversion[["path"]], args), collapse = " "), tfile)
+    subprocess::spawn_process(tfile, arguments = c(">", outTfile,
+                                                   "2>", errTfile))
+  }else{
+    subprocess::spawn_process(
+      phantomversion[["path"]], arguments = args
+    )
+  }
   if(!is.na(subprocess::process_return_code(phantomdrv))){
     stop("PhantomJS couldn't be started",
          subprocess::process_read(phantomdrv, "stderr"))
@@ -66,14 +77,16 @@ phantomjs <- function(port = 4567L, version = "2.1.1", check = TRUE,
   list(
     process = phantomdrv,
     output = function(timeout = 0L){
-      infun_read(phantomdrv, log, "stdout", timeout = timeout)
+      infun_read(phantomdrv, log, "stdout", timeout = timeout,
+                 outfile = outTfile, errfile = errTfile)
     },
     error = function(timeout = 0L){
-      infun_read(phantomdrv, log, "stderr", timeout = timeout)
+      infun_read(phantomdrv, log, "stderr", timeout = timeout,
+                 outfile = outTfile, errfile = errTfile)
     },
     stop = function(){subprocess::process_kill(phantomdrv)},
     log = function(){
-      infun_read(phantomdrv, log)
+      infun_read(phantomdrv, log, outfile = outTfile, errfile = errTfile)
       as.list(log)
     }
   )

--- a/R/selenium.R
+++ b/R/selenium.R
@@ -80,9 +80,18 @@ selenium <- function(port = 4567L,
   if(retcommand){
     return(paste(c(javapath, jvmargs, selargs), collapse = " "))
   }
-  seleniumdrv <- subprocess::spawn_process(
-    javapath, arguments = c(jvmargs, selargs)
-  )
+  seleniumdrv <- if(identical(.Platform[["OS.type"]], "windows")){
+    tfile <- tempfile(fileext = ".bat")
+    errTfile <- tempfile(fileext = ".log")
+    outTfile <- tempfile(fileext = ".log")
+    write(paste(c(javapath, jvmargs, selargs), collapse = " "), tfile)
+    subprocess::spawn_process(tfile, arguments = c(">", outTfile,
+                                                   "2>", errTfile))
+  }else{
+    subprocess::spawn_process(
+      javapath, arguments = c(jvmargs, selargs)
+    )
+  }
   if(!is.na(subprocess::process_return_code(seleniumdrv))){
     stop("Selenium server couldn't be started",
          subprocess::process_read(seleniumdrv, "stderr"))


### PR DESCRIPTION
This pull request should address #2. On windows subprocess uses blocking pipes. This results in
blocking (unsurprisingly) which manifests itself as the selenium server/ other drivers hanging. 

This is addressed by running the process as a batch file on Windows with stdout/stderr being directed to
their own temporary files. An internal read_pipes function handles the reading of the files so from a user prospective the output/error/log functions returned from the driver functions should be consistent across
platforms.