### PR TITLE
Fix test failures from mocking of functions from base packages

### DIFF
--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -1,11 +1,15 @@
 context("chrome")
+
+normalizePath <- function(...) base::normalizePath(...)
+list.files <- function(...) base::list.files(...)
+
 test_that("canCallChrome", {
   with_mock(
     `binman::process_yaml` = binman_process_yaml,
     `binman::list_versions` = mock_binman_list_versions_chrome,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
@@ -44,8 +48,8 @@ test_that("pickUpErrorFromReturnCode", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_chrome,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` = function(...){"some error"},
     `subprocess::process_read` =
@@ -63,8 +67,8 @@ test_that("pickUpErrorFromPortInUse", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_chrome,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,

--- a/tests/testthat/test-gecko.R
+++ b/tests/testthat/test-gecko.R
@@ -1,12 +1,15 @@
 context("gecko")
 
+normalizePath <- function(...) base::normalizePath(...)
+list.files <- function(...) base::list.files(...)
+
 test_that("canCallGecko", {
   with_mock(
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_gecko,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
@@ -45,8 +48,8 @@ test_that("pickUpErrorFromReturnCode", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_gecko,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` = function(...){"some error"},
     `subprocess::process_read` =
@@ -64,8 +67,8 @@ test_that("pickUpErrorFromPortInUse", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_gecko,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,

--- a/tests/testthat/test-iedriver.R
+++ b/tests/testthat/test-iedriver.R
@@ -1,17 +1,21 @@
 context("iedriver")
 
+normalizePath <- function(...) base::normalizePath(...)
+list.files <- function(...) base::list.files(...)
+Sys.info <- function(...) base::Sys.info(...)
+
 test_that("canCallIEDriver", {
   with_mock(
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_iedriver,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
     `subprocess::process_kill` = mock_subprocess_process_kill,
-    `base::Sys.info` = function(...){
+      Sys.info = function(...){
       structure("Windows", .Names = "sysname")
     },
     `wdman:::generic_start_log` = mock_generic_start_log,
@@ -47,14 +51,14 @@ test_that("pickUpErrorFromReturnCode", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_iedriver,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` = function(...){"some error"},
     `subprocess::process_read` =
       mock_subprocess_process_read_selenium,
     `wdman:::generic_start_log` = mock_generic_start_log,
-    `base::Sys.info` = function(...){
+     Sys.info = function(...){
       structure("Windows", .Names = "sysname")
     },
     {
@@ -69,8 +73,8 @@ test_that("pickUpErrorFromPortInUse", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_iedriver,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
@@ -80,7 +84,7 @@ test_that("pickUpErrorFromPortInUse", {
     `wdman:::generic_start_log` = function(...){
       list(stderr = "Address in use")
     },
-    `base::Sys.info` = function(...){
+    Sys.info = function(...){
       structure("Windows", .Names = "sysname")
     },
     {

--- a/tests/testthat/test-phantom.R
+++ b/tests/testthat/test-phantom.R
@@ -1,12 +1,16 @@
 context("phantom")
 
+normalizePath <- function(...) base::normalizePath(...)
+list.files <- function(...) base::list.files(...)
+
+
 test_that("canCallPhantomJS", {
   with_mock(
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_phantomjs,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
@@ -45,8 +49,8 @@ test_that("pickUpErrorFromReturnCode", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_phantomjs,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` = function(...){"some error"},
     `subprocess::process_read` =
@@ -64,8 +68,8 @@ test_that("pickUpErrorFromPortInUse", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_phantomjs,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,

--- a/tests/testthat/test-selenium.R
+++ b/tests/testthat/test-selenium.R
@@ -1,12 +1,17 @@
 context("selenium")
 
+normalizePath <- function(...) base::normalizePath(...)
+list.files <- function(...) base::list.files(...)
+Sys.info <- function(...) base::Sys.info(...)
+Sys.which <- function(...) base::Sys.which(...)
+
 test_that("canCallSelenium", {
   with_mock(
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_selenium,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
@@ -15,7 +20,7 @@ test_that("canCallSelenium", {
     `subprocess::process_kill` = mock_subprocess_process_kill,
     `wdman:::generic_start_log` = mock_generic_start_log,
     `wdman:::infun_read` = function(...){"infun"},
-    `base::Sys.info` = function(...){
+     Sys.info = function(...){
       structure("Windows", .Names = "sysname")
     },
     # CHROME
@@ -73,14 +78,14 @@ test_that("canCallSelenium", {
 
 test_that("errorIfJavaNotFound", {
   with_mock(
-    `base::Sys.which`= function(...){""},
+     Sys.which= function(...){""},
     expect_error(selenium(), "PATH to JAVA not found")
   )
 })
 
 test_that("errorIfVersionNotFound", {
   with_mock(
-    `base::Sys.which`= function(...){"im here"},
+     Sys.which= function(...){"im here"},
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_selenium,
     expect_error(selenium(version = "nothere"),
@@ -93,14 +98,14 @@ test_that("pickUpErrorFromReturnCode", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_selenium,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` = function(...){"some error"},
     `subprocess::process_read` =
       mock_subprocess_process_read_selenium,
     `wdman:::generic_start_log` = mock_generic_start_log,
-    `base::Sys.info` = function(...){
+     Sys.info = function(...){
       structure("Windows", .Names = "sysname")
     },
     # CHROME
@@ -141,8 +146,8 @@ test_that("pickUpErrorFromPortInUse", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_selenium,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
@@ -152,7 +157,7 @@ test_that("pickUpErrorFromPortInUse", {
     `wdman:::generic_start_log` = function(...){
       list(stderr = "Address already in use")
     },
-    `base::Sys.info` = function(...){
+     Sys.info = function(...){
       structure("Windows", .Names = "sysname")
     },
     # CHROME
@@ -192,8 +197,8 @@ test_that("pickUpWarningOnNoStderr", {
     `binman::process_yaml` = function(...){},
     `binman::list_versions` = mock_binman_list_versions_selenium,
     `binman::app_dir` = mock_binman_app_dir,
-    `base::normalizePath` = mock_base_normalizePath,
-    `base::list.files` = mock_base_list.files,
+     normalizePath = mock_base_normalizePath,
+     list.files = mock_base_list.files,
     `subprocess::spawn_process` = mock_subprocess_spawn_process,
     `subprocess::process_return_code` =
       mock_subprocess_process_return_code,
@@ -201,7 +206,7 @@ test_that("pickUpWarningOnNoStderr", {
       mock_subprocess_process_read_selenium,
     `wdman:::generic_start_log` =
       function(...){list(stdout = character(), stderr = character())},
-    `base::Sys.info` = function(...){
+     Sys.info = function(...){
       structure("Windows", .Names = "sysname")
     },
     # CHROME


### PR DESCRIPTION
Note that perhaps mockr (https://cran.r-project.org/web/packages/mockr/index.html) would provide a more stable approach if testthat::with_mock is being depreciated. (cf https://github.com/r-lib/testthat/issues/546)