### PR TITLE
Fixing Mac install problem introduced by new chromedriver binaries for Mac M1

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -112,7 +112,6 @@ chrome_check <- function(verbose, check = TRUE){
   
   tempyml <- tempfile(fileext = ".yml")
   write(yaml::as.yaml(cyml), tempyml)
-  cat(yaml::as.yaml(cyml))
   if(check){
     if(verbose) message("checking chromedriver versions:")
     process_yaml(tempyml, verbose)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -87,6 +87,11 @@ chrome <- function(port = 4567L, version = "latest", path = "wd/hub",
   )
 }
 
+# Figure out if installing on an Intel or M1 mac
+mac_machine <- function() {
+   ifelse(Sys.info()['machine']=="arm64", "mac64-m1", "mac[3264]{2}$")
+}
+
 chrome_check <- function(verbose, check = TRUE){
   chromeyml <- system.file("yaml", "chromedriver.yml", package = "wdman")
   cyml <- yaml::yaml.load_file(chromeyml)
@@ -95,11 +100,19 @@ chrome_check <- function(verbose, check = TRUE){
     switch(Sys.info()["sysname"],
            Linux = grep(os_arch("linux"), cyml[[platvec]], value = TRUE),
            Windows = grep("win", cyml[[platvec]], value = TRUE),
-           Darwin = grep("mac", cyml[[platvec]], value = TRUE),
+           Darwin = grep(mac_machine(), cyml[[platvec]], value = TRUE),
            stop("Unknown OS")
     )
+  platregexvec <- c("predlfunction", "binman::predl_google_storage", "platformregex")
+
+  # Need regex that can tell mac64 and mac64_m1 apart
+  if (cyml[[platvec]] %in% c("mac64", "mac64-m1")) {
+    cyml[[platregexvec]] <- paste0(cyml[[platvec]], "\\.")
+  }
+  
   tempyml <- tempfile(fileext = ".yml")
   write(yaml::as.yaml(cyml), tempyml)
+  cat(yaml::as.yaml(cyml))
   if(check){
     if(verbose) message("checking chromedriver versions:")
     process_yaml(tempyml, verbose)

--- a/inst/yaml/chromedriver.yml
+++ b/inst/yaml/chromedriver.yml
@@ -3,6 +3,7 @@ predlfunction:
   "binman::predl_google_storage":
     url: https://www.googleapis.com/storage/v1/b/chromedriver/o
     platform:
+    - mac64-m1
     - mac64
     - linux32
     - linux64


### PR DESCRIPTION
As described in #25, the introduction of new binaries for Mac M1 was leading to both the mac64 and mac64-m1 chromedriver binaries being downloaded and the m1 binary being installed on Mac Intel machines (at least on mine :)).   This pull request adds  `mac64-m1` to the list of platforms in `chromedriver.yml` and adds a few lines to `chrome.R` that determine if the mac64 or mac64-m1 binary is needed and then installs the correct binary. 

I haven't tested this on an M1 machine, but it does work on (my) mac64 (Intel) platform.  

I tried to address the issue in a way to involved the least amount of change.  Arguably, it would be better to provide a more elegant fix that would generally allow for the possibility that one platform name could be a substring of another which is the root cause of the current problem.   