### PR TITLE
Fix leaving orphaned processes on server close.

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -63,7 +63,7 @@ chrome <- function(port = 4567L, version = "latest", path = "wd/hub",
                                 errfile = pfile[["err"]])
   if(length(startlog[["stderr"]]) >0){
     if(any(grepl("Address already in use", startlog[["stderr"]]))){
-      chromedrv$kill()
+      kill_process(chromedrv)
       stop("Chrome Driver signals port = ", port, " is already in use.")
     }
   }
@@ -78,7 +78,7 @@ chrome <- function(port = 4567L, version = "latest", path = "wd/hub",
       infun_read(chromedrv, log, "stderr", timeout = timeout,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])
     },
-    stop = function(){chromedrv$kill()},
+    stop = function(){kill_process(chromedrv)},
     log = function(){
       infun_read(chromedrv, log,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])

--- a/R/gecko.R
+++ b/R/gecko.R
@@ -61,7 +61,7 @@ gecko <- function(port = 4567L, version = "latest", check = TRUE,
                                 errfile = pfile[["err"]])
   if(length(startlog[["stderr"]]) >0){
     if(any(grepl("Address already in use", startlog[["stderr"]]))){
-      geckodrv$kill()
+      kill_process(geckodrv)
       stop("Gecko Driver signals port = ", port, " is already in use.")
     }
   }
@@ -76,7 +76,7 @@ gecko <- function(port = 4567L, version = "latest", check = TRUE,
       infun_read(geckodrv, log, "stderr", timeout = timeout,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])
     },
-    stop = function(){geckodrv$kill()},
+    stop = function(){kill_process(geckodrv)},
     log = function(){
       infun_read(geckodrv, log, outfile = pfile[["out"]], errfile = pfile[["err"]])
       as.list(log)

--- a/R/iedriver.R
+++ b/R/iedriver.R
@@ -62,7 +62,7 @@ iedriver <- function(port = 4567L, version = "latest", check = TRUE,
                                 errfile = pfile[["err"]])
   if(length(startlog[["stderr"]]) >0){
     if(any(grepl("Address already in use", startlog[["stderr"]]))){
-      iedrv$kill()
+      kill_process(iedrv)
       stop("IE Driver signals port = ", port, " is already in use.")
     }
   }
@@ -77,7 +77,7 @@ iedriver <- function(port = 4567L, version = "latest", check = TRUE,
       infun_read(iedrv, log, "stderr", timeout = timeout,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])
     },
-    stop = function(){iedrv$kill()},
+    stop = function(){kill_process(iedrv)},
     log = function(){
       infun_read(iedrv, log, outfile = pfile[["out"]], errfile = pfile[["err"]])
       as.list(log)

--- a/R/phantom.R
+++ b/R/phantom.R
@@ -62,7 +62,7 @@ phantomjs <- function(port = 4567L, version = "2.1.1", check = TRUE,
     if(any(
       grepl("GhostDriver - main.fail.*sourceURL", startlog[["stdout"]])
     )){
-      phantomdrv$kill()
+      kill_process(phantomdrv)
       stop("PhantomJS signals port = ", port, " is already in use.")
     }
   }
@@ -77,7 +77,7 @@ phantomjs <- function(port = 4567L, version = "2.1.1", check = TRUE,
       infun_read(phantomdrv, log, "stderr", timeout = timeout,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])
     },
-    stop = function(){phantomdrv$kill()},
+    stop = function(){kill_process(phantomdrv)},
     log = function(){
       infun_read(phantomdrv, log,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])

--- a/R/selenium.R
+++ b/R/selenium.R
@@ -96,7 +96,7 @@ selenium <- function(port = 4567L,
                                 errfile = pfile[["err"]])
   if(length(startlog[["stderr"]]) >0){
     if(any(grepl("Address already in use", startlog[["stderr"]]))){
-      seleniumdrv$kill()
+      kill_process(seleniumdrv)
       stop("Selenium server signals port = ", port, " is already in use.")
     }
   }else{
@@ -116,7 +116,7 @@ selenium <- function(port = 4567L,
       infun_read(seleniumdrv, log, "stderr", timeout = timeout,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])
     },
-    stop = function(){seleniumdrv$kill()},
+    stop = function(){kill_process(seleniumdrv)},
     log = function(){
       infun_read(seleniumdrv, log,
                  outfile = pfile[["out"]], errfile = pfile[["err"]])

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,7 +76,7 @@ unix_spawn_tofile <- function(command, args, outfile, errfile, ...){
                 shQuote(outfile), "2>", shQuote(errfile)), collapse = " "),
         tfile, append = TRUE)
   Sys.chmod(tfile)
-  processx::process$new(tfile)
+  processx::process$new(tfile, cleanup_tree = TRUE)
 }
 
 windows_spawn_tofile <- function(command, args, outfile, errfile, ...){
@@ -84,7 +84,7 @@ windows_spawn_tofile <- function(command, args, outfile, errfile, ...){
   write(paste(c(shQuote(command), args, ">",
                 shQuote(outfile), "2>", shQuote(errfile)), collapse = " "),
         tfile)
-  processx::process$new(tfile)
+  processx::process$new(tfile, cleanup_tree = TRUE)
 }
 
 spawn_tofile <- function(command, args, outfile, errfile, ...){
@@ -101,4 +101,12 @@ pipe_files <- function(){
   outTfile <- tempfile(fileext = ".txt")
   write(character(), outTfile)
   list(out = outTfile, err = errTfile)
+}
+
+kill_process <- function(p){
+  # Kill a process and all its child processes, returning true if process was
+  # killed and false if not
+  r <- p$kill()
+  p$kill_tree()
+  r
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,7 +76,7 @@ unix_spawn_tofile <- function(command, args, outfile, errfile, ...){
                 shQuote(outfile), "2>", shQuote(errfile)), collapse = " "),
         tfile, append = TRUE)
   Sys.chmod(tfile)
-  processx::process$new(tfile)
+  processx::process$new(tfile, cleanup_tree = TRUE)
 }
 
 windows_spawn_tofile <- function(command, args, outfile, errfile, ...){
@@ -84,7 +84,7 @@ windows_spawn_tofile <- function(command, args, outfile, errfile, ...){
   write(paste(c(shQuote(command), args, ">",
                 shQuote(outfile), "2>", shQuote(errfile)), collapse = " "),
         tfile)
-  processx::process$new(tfile)
+  processx::process$new(tfile, cleanup_tree = TRUE)
 }
 
 spawn_tofile <- function(command, args, outfile, errfile, ...){


### PR DESCRIPTION
 Fix the leaving of orphans upon server close.

* Add cleanup_tree = TRUE to process creation to kill child processes during garbage collection of the process object.
* Create kill_process function to kill both the main process via kill() and child processes via kill_tree(). Return the result of kill() so that return values are unchanged from before. Use this function everywhere the kill() method was used previously.

The kill_tree() method in processx depends on the ps package supporting the system, so this may break some functionality on systems that are not Windows, OSX, or Linux.

This is to address issue #29 in this repository.