### PR TITLE
Select correct chromedriver binary

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -143,7 +143,7 @@ chrome_ver <- function(platform, version) {
     file.path(app_dir("chromedriver"), platform, chromever)
   )
   chromepath <- list.files(chromedir,
-    pattern = "chromedriver($|.exe$)",
+    pattern = "^chromedriver($|.exe$)",
     full.names = TRUE
   )
   list(version = chromever, dir = chromedir, path = chromepath)


### PR DESCRIPTION
This will stop LICENSE.chromedriver files from giving an error on selenium()